### PR TITLE
Load local vendor folder first

### DIFF
--- a/core.php
+++ b/core.php
@@ -22,9 +22,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! class_exists( \Tribe\Alert\Core::class ) ) {
 	// Require the vendor folder via multiple locations
 	$autoloaders = (array) apply_filters( 'tribe/alerts/autoloaders', [
+		trailingslashit( __DIR__ ) . 'vendor/autoload.php',
 		trailingslashit( WP_CONTENT_DIR ) . '../vendor/autoload.php',
 		trailingslashit( WP_CONTENT_DIR ) . 'vendor/autoload.php',
-		trailingslashit( __DIR__ ) . 'vendor/autoload.php',
 	] );
 
 	$autoload = current( array_filter( $autoloaders, 'file_exists' ) );


### PR DESCRIPTION
- In the event we need to install this on older projects, they will have composer conflicts with some of our dependencies. This will allow for an isolated install without loading the root's vendor folder first.