### PR TITLE
Include core.php in php-scoper file

### DIFF
--- a/core.php
+++ b/core.php
@@ -4,7 +4,7 @@
  * Plugin Name:       Tribe Alerts
  * Plugin URI:        https://github.com/moderntribe/tribe-alerts
  * Description:       Tribe Alerts WordPress Plugin
- * Version:           1.0.6
+ * Version:           1.0.7
  * Requires PHP:      7.4
  * Author:            Modern Tribe
  * Author URI:        https://tri.be

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -42,6 +42,7 @@ return [
 			  ->in( 'vendor' ),
 		Finder::create()->append( [
 			'composer.json',
+			'core.php',
 		] ),
 	],
 


### PR DESCRIPTION
- BUGFIX: include core.php when scoping files, so namespaces properly get updated.