### PR TITLE
Add use statements so php-scoper picks them up

### DIFF
--- a/core.php
+++ b/core.php
@@ -14,12 +14,16 @@
  * Domain Path:       /languages
  */
 
+use Tribe\Alert\Activation\Activator;
+use Tribe\Alert\Activation\Deactivator;
+use Tribe\Alert\Core;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die;
 }
 
 // Prevent duplicate autoloading during tests
-if ( ! class_exists( \Tribe\Alert\Core::class ) ) {
+if ( ! class_exists( Core::class ) ) {
 	// Require the vendor folder via multiple locations
 	$autoloaders = (array) apply_filters( 'tribe/alerts/autoloaders', [
 		trailingslashit( __DIR__ ) . 'vendor/autoload.php',
@@ -50,9 +54,9 @@ add_action( 'plugins_loaded', static function (): void {
 }, 5, 0 );
 
 
-function tribe_alert(): \Tribe\Alert\Core {
-	return \Tribe\Alert\Core::instance();
+function tribe_alert(): Core {
+	return Core::instance();
 }
 
-register_activation_hook( __FILE__, new \Tribe\Alert\Activation\Activator() );
-register_deactivation_hook( __FILE__, new \Tribe\Alert\Activation\Deactivator() );
+register_activation_hook( __FILE__, new Activator() );
+register_deactivation_hook( __FILE__, new Deactivator() );

--- a/core.php
+++ b/core.php
@@ -4,7 +4,7 @@
  * Plugin Name:       Tribe Alerts
  * Plugin URI:        https://github.com/moderntribe/tribe-alerts
  * Description:       Tribe Alerts WordPress Plugin
- * Version:           1.0.7
+ * Version:           1.0.8
  * Requires PHP:      7.4
  * Author:            Modern Tribe
  * Author URI:        https://tri.be


### PR DESCRIPTION
- BUGFIX: utilize `use` statements in core.php so PHP-Scoper properly changes them