### PR TITLE
Bugfix/scoper acf namespace

### DIFF
--- a/core.php
+++ b/core.php
@@ -4,7 +4,7 @@
  * Plugin Name:       Tribe Alerts
  * Plugin URI:        https://github.com/moderntribe/tribe-alerts
  * Description:       Tribe Alerts WordPress Plugin
- * Version:           1.0.10
+ * Version:           1.0.11
  * Requires PHP:      7.4
  * Author:            Modern Tribe
  * Author URI:        https://tri.be

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -78,7 +78,7 @@ return [
 		// '',                            // Any namespace
 	],
 	'exclude-classes'         => [
-		// 'ReflectionClassConstant',
+		'ACF',
 	],
 	'exclude-functions'       => [
 		// 'mb_str_split',


### PR DESCRIPTION
- BUGFIX: exclude `ACF` class from being prefixed by the PHP-Scoper