### PR TITLE
[MSLOCAL-23]: Admin notice when missing acf swatch plugin

### DIFF
--- a/core.php
+++ b/core.php
@@ -52,6 +52,20 @@ add_action( 'plugins_loaded', static function (): void {
 		return;
 	}
 
+	if ( defined( 'TRIBE_ALERTS_COLOR_OPTIONS' ) &&
+	     TRIBE_ALERTS_COLOR_OPTIONS &&
+	     ! function_exists( 'include_field_types_swatch' )
+	) {
+		add_action(
+			'admin_notices',
+			static function (): void { ?>
+				<div class="notice notice-error">
+					<p><?php esc_html_e( 'Tribe Alerts requires the "Advanced Custom Fields: Color Swatches" plugin to be installed and activated!', 'tribe-alerts' ); ?></p>
+				</div>
+			<?php }
+		);
+	}
+
 	tribe_alert()->init( __FILE__ );
 }, 5, 0 );
 

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -130,6 +130,7 @@ return [
 	], scoper_wp_file( 'exclude-wordpress-classes.json' ) ),
 	'exclude-functions'       => array_merge( [
 		'/^acf_/',
+		'include_field_types_swatch',
 	], scoper_wp_file( 'exclude-wordpress-functions.json' ) ),
 	'exclude-constants'       => scoper_wp_file( 'exclude-wordpress-constants.json' ),
 


### PR DESCRIPTION
https://moderntribe.atlassian.net/browse/MSLOCAL-23

- Adds a warning in the dashboard if the developer intends to use the color options but doesn't have the acf swatch plugin installed or activated.