### PR TITLE
Bugfix: fatal errors on empty search results

### DIFF
--- a/dev/tests/tests/functional/Alert_Cest.php
+++ b/dev/tests/tests/functional/Alert_Cest.php
@@ -70,6 +70,13 @@ final class Alert_Cest {
 		$I->dontSeeElement( '.tribe-alerts' );
 		$I->dontSee( 'Fatal error', 'b' );
 		$I->dontSeeInSource( 'Uncaught TypeError' );
+
+		$I->amOnPage( '/category/uncategorized/' );
+		$I->seeResponseCodeIs( 200 );
+		$I->seeInSource( '<!-- tribe alerts -->' );
+		$I->dontSeeElement( '.tribe-alerts' );
+		$I->dontSee( 'Fatal error', 'b' );
+		$I->dontSeeInSource( 'Uncaught TypeError' );
 	}
 
 	public function test_it_includes_alert_on_specific_posts( FunctionalTester $I ) {
@@ -127,6 +134,16 @@ final class Alert_Cest {
 		$I->seeInSource( '<!-- tribe alerts -->' );
 		$I->seeElement( '.tribe-alerts' );
 		$I->see( 'Test included alert message' );
+
+		$I->amOnPage( '/?s=meep' );
+		$I->seeResponseCodeIs( 200 );
+		$I->seeInSource( '<!-- tribe alerts -->' );
+		$I->dontSeeElement( '.tribe-alerts' );
+
+		$I->amOnPage( '/category/uncategorized/' );
+		$I->seeResponseCodeIs( 200 );
+		$I->seeInSource( '<!-- tribe alerts -->' );
+		$I->dontSeeElement( '.tribe-alerts' );
 	}
 
 	public function test_it_displays_a_global_alert_on_multiple_urls( FunctionalTester $I ) {
@@ -160,6 +177,18 @@ final class Alert_Cest {
 		$I->amOnPage( '/regular-post' );
 		$I->seeResponseCodeIs( 200 );
 
+		$I->seeInSource( '<!-- tribe alerts -->' );
+		$I->seeElement( '.tribe-alerts' );
+		$I->see( 'Test alert message' );
+
+		$I->amOnPage( '/?s=meep' );
+		$I->seeResponseCodeIs( 200 );
+		$I->seeInSource( '<!-- tribe alerts -->' );
+		$I->seeElement( '.tribe-alerts' );
+		$I->see( 'Test alert message' );
+
+		$I->amOnPage( '/category/uncategorized/' );
+		$I->seeResponseCodeIs( 200 );
 		$I->seeInSource( '<!-- tribe alerts -->' );
 		$I->seeElement( '.tribe-alerts' );
 		$I->see( 'Test alert message' );

--- a/dev/tests/tests/functional/Alert_Cest.php
+++ b/dev/tests/tests/functional/Alert_Cest.php
@@ -1,4 +1,4 @@
-<?php declare( strict_types=1 );
+<?php declare(strict_types=1);
 
 use Tribe\Alert\Components\Alert\Alert_Color_Options;
 use Tribe\Alert\Components\Alert\Alert_Controller;
@@ -6,7 +6,7 @@ use Tribe\Alert\Meta\Alert_Meta;
 use Tribe\Alert\Meta\Alert_Settings_Meta;
 use Tribe\Alert\Post_Types\Alert\Alert;
 
-class Alert_Cest {
+final class Alert_Cest {
 
 	public function test_it_excludes_alert_from_post( FunctionalTester $I ) {
 		$alert_id = $I->havePostInDatabase( [
@@ -62,6 +62,14 @@ class Alert_Cest {
 		$I->seeInSource( '<!-- tribe alerts -->' );
 		$I->seeElement( '.tribe-alerts' );
 		$I->see( 'Test excluded alert message' );
+
+		// Validate pipeline bug was fixed on search page (or any page without a $post global)
+		$I->amOnPage( '/?s=meep' );
+		$I->seeResponseCodeIs( 200 );
+		$I->seeInSource( '<!-- tribe alerts -->' );
+		$I->dontSeeElement( '.tribe-alerts' );
+		$I->dontSee( 'Fatal error', 'b' );
+		$I->dontSeeInSource( 'Uncaught TypeError' );
 	}
 
 	public function test_it_includes_alert_on_specific_posts( FunctionalTester $I ) {

--- a/dev/tests/tests/integration/Tribe/Components/Alert/Rules/Alert_Rule_Test.php
+++ b/dev/tests/tests/integration/Tribe/Components/Alert/Rules/Alert_Rule_Test.php
@@ -60,6 +60,8 @@ final class Alert_Rule_Test extends Test_Case {
 		$closure = static fn() => false;
 
 		// Test each post would show the alert.
+		$GLOBALS['wp_query']->is_singular = true;
+
 		foreach ( $included as $post_id ) {
 			$GLOBALS['post'] = get_post( $post_id );
 
@@ -103,9 +105,10 @@ final class Alert_Rule_Test extends Test_Case {
 		}
 
 		// Mock the current post is not in the excluded list.
-		$_post           = clone $GLOBALS['post'];
-		$_post->ID       = 99999;
-		$GLOBALS['post'] = $_post;
+		$_post                            = clone $GLOBALS['post'];
+		$_post->ID                        = 99999;
+		$GLOBALS['post']                  = $_post;
+		$GLOBALS['wp_query']->is_singular = true;
 
 		$this->assertTrue( $rule->handle( false, $closure, $rules ) );
 	}

--- a/dev/tests/tests/integration/Tribe/Components/Alert/Rules/Alert_Rule_Test.php
+++ b/dev/tests/tests/integration/Tribe/Components/Alert/Rules/Alert_Rule_Test.php
@@ -35,7 +35,7 @@ final class Alert_Rule_Test extends Test_Case {
 		$rule    = new Display_All_Rule();
 		$closure = static fn() => false;
 
-		$this->assertTrue( $rule->handle( $rules, $closure ) );
+		$this->assertTrue( $rule->handle( false, $closure, $rules ) );
 	}
 
 	public function test_it_would_only_display_on_certain_pages(): void {
@@ -63,7 +63,7 @@ final class Alert_Rule_Test extends Test_Case {
 		foreach ( $included as $post_id ) {
 			$GLOBALS['post'] = get_post( $post_id );
 
-			$this->assertTrue( $rule->handle( $rules, $closure ) );
+			$this->assertTrue( $rule->handle( false, $closure, $rules ) );
 		}
 
 		// Mock the current post is not in the included list.
@@ -71,7 +71,7 @@ final class Alert_Rule_Test extends Test_Case {
 		$_post->ID       = 99999;
 		$GLOBALS['post'] = $_post;
 
-		$this->assertFalse( $rule->handle( $rules, $closure ) );
+		$this->assertFalse( $rule->handle( false, $closure, $rules ) );
 	}
 
 	public function test_it_would_exclude_certain_pages(): void {
@@ -99,7 +99,7 @@ final class Alert_Rule_Test extends Test_Case {
 		foreach ( $excluded as $post_id ) {
 			$GLOBALS['post'] = get_post( $post_id );
 
-			$this->assertFalse( $rule->handle( $rules, $closure ) );
+			$this->assertFalse( $rule->handle( false, $closure, $rules ) );
 		}
 
 		// Mock the current post is not in the excluded list.
@@ -107,7 +107,7 @@ final class Alert_Rule_Test extends Test_Case {
 		$_post->ID       = 99999;
 		$GLOBALS['post'] = $_post;
 
-		$this->assertTrue( $rule->handle( $rules, $closure ) );
+		$this->assertTrue( $rule->handle( false, $closure, $rules ) );
 	}
 
 }

--- a/src/Components/Alert/Alert_Rule_Manager.php
+++ b/src/Components/Alert/Alert_Rule_Manager.php
@@ -26,7 +26,7 @@ class Alert_Rule_Manager {
 			return false;
 		}
 
-		return $this->pipeline->send( $rules )->thenReturn();
+		return $this->pipeline->send( false, [ $rules ] )->thenReturn();
 	}
 
 }

--- a/src/Components/Alert/Rule.php
+++ b/src/Components/Alert/Rule.php
@@ -10,11 +10,12 @@ interface Rule {
 	 * Determine if we should display an alert. A rule can return
 	 * a result or pass itself onto the next rule for processing.
 	 *
-	 * @param mixed[]  $rules The Alert Meta ACF Rules Group.
-	 * @param \Closure $next  The next rule in the pipeline.
+	 * @param bool     $display Whether an alert will display.
+	 * @param \Closure $next    The next rule in the pipeline.
+	 * @param mixed[]  $rules   The Alert Meta ACF Rules Group.
 	 *
 	 * @return bool
 	 */
-	public function handle( array $rules, Closure $next ): bool;
+	public function handle( bool $display, Closure $next, array $rules ): bool;
 
 }

--- a/src/Components/Alert/Rules/Display_All_Rule.php
+++ b/src/Components/Alert/Rules/Display_All_Rule.php
@@ -13,14 +13,14 @@ class Display_All_Rule implements Rule {
 	 *
 	 * @inheritDoc
 	 */
-	public function handle( array $rules, Closure $next ): bool {
+	public function handle( bool $display, Closure $next, array $rules ): bool {
 		$type = $rules[ Alert_Meta::FIELD_RULES_DISPLAY_TYPE ] ?? '';
 
 		if ( $type === Alert_Meta::OPTION_EVERY_PAGE ) {
 			return true;
 		}
 
-		return $next( $rules );
+		return $next( $display );
 	}
 
 }

--- a/src/Components/Alert/Rules/Excluded_Posts_Rule.php
+++ b/src/Components/Alert/Rules/Excluded_Posts_Rule.php
@@ -13,14 +13,14 @@ class Excluded_Posts_Rule implements Rule {
 	 *
 	 * @inheritDoc
 	 */
-	public function handle( array $rules, Closure $next ): bool {
+	public function handle( bool $display, Closure $next, array $rules ): bool {
 		$type = $rules[ Alert_Meta::FIELD_RULES_DISPLAY_TYPE ] ?? '';
 
 		if ( $type === Alert_Meta::OPTION_EXCLUDE ) {
 			$post = get_post();
 
 			if ( ! isset( $post->ID ) ) {
-				return $next( $rules );
+				return $next( $display );
 			}
 
 			$excluded_posts = $rules[ Alert_Meta::FIELD_RULES_EXCLUDE_PAGES ] ?? [];
@@ -34,7 +34,7 @@ class Excluded_Posts_Rule implements Rule {
 			return true;
 		}
 
-		return $next( $rules );
+		return $next( $display );
 	}
 
 }

--- a/src/Components/Alert/Rules/Excluded_Posts_Rule.php
+++ b/src/Components/Alert/Rules/Excluded_Posts_Rule.php
@@ -17,6 +17,10 @@ class Excluded_Posts_Rule implements Rule {
 		$type = $rules[ Alert_Meta::FIELD_RULES_DISPLAY_TYPE ] ?? '';
 
 		if ( $type === Alert_Meta::OPTION_EXCLUDE ) {
+			if ( ! is_singular() ) {
+				return false;
+			}
+
 			$post = get_post();
 
 			if ( ! isset( $post->ID ) ) {

--- a/src/Components/Alert/Rules/Included_Posts_Rule.php
+++ b/src/Components/Alert/Rules/Included_Posts_Rule.php
@@ -17,6 +17,10 @@ class Included_Posts_Rule implements Rule {
 		$type = $rules[ Alert_Meta::FIELD_RULES_DISPLAY_TYPE ] ?? '';
 
 		if ( $type === Alert_Meta::OPTION_INCLUDE ) {
+			if ( ! is_singular() ) {
+				return false;
+			}
+
 			$post = get_post();
 
 			if ( ! isset( $post->ID ) ) {

--- a/src/Components/Alert/Rules/Included_Posts_Rule.php
+++ b/src/Components/Alert/Rules/Included_Posts_Rule.php
@@ -13,14 +13,14 @@ class Included_Posts_Rule implements Rule {
 	 *
 	 * @inheritDoc
 	 */
-	public function handle( array $rules, Closure $next ): bool {
+	public function handle( bool $display, Closure $next, array $rules ): bool {
 		$type = $rules[ Alert_Meta::FIELD_RULES_DISPLAY_TYPE ] ?? '';
 
 		if ( $type === Alert_Meta::OPTION_INCLUDE ) {
 			$post = get_post();
 
 			if ( ! isset( $post->ID ) ) {
-				return $next( $rules );
+				return $next( $display );
 			}
 
 			$included_posts = $rules[ Alert_Meta::FIELD_RULES_INCLUDE_PAGES ] ?? [];
@@ -34,7 +34,7 @@ class Included_Posts_Rule implements Rule {
 			return false;
 		}
 
-		return $next( $rules );
+		return $next( $display );
 	}
 
 }

--- a/src/Meta/Alert_Meta.php
+++ b/src/Meta/Alert_Meta.php
@@ -156,7 +156,7 @@ class Alert_Meta extends ACF\ACF_Meta_Group {
 			'name'          => self::FIELD_RULES_DISPLAY_TYPE,
 			'type'          => 'radio',
 			'choices'       => [
-				self::OPTION_EVERY_PAGE => esc_html__( 'Show on every page', 'tribe-alerts' ),
+				self::OPTION_EVERY_PAGE => esc_html__( 'Show everywhere', 'tribe-alerts' ),
 				self::OPTION_INCLUDE    => esc_html__( 'Show only on specified pages', 'tribe-alerts' ),
 				self::OPTION_EXCLUDE    => esc_html__( 'Exclude from specific pages', 'tribe-alerts' ),
 			],


### PR DESCRIPTION
https://moderntribe.atlassian.net/browse/MSSA-226

- BUGFIX: fatal error on WordPress URLs that don't have a `$post` global (e.g. search with no results) by properly coding the pipeline stages.
- BUGFIX: If the included or excluded rule are active, just do not display the banner if not on a singular post.