### PR TITLE
BUGFIX: Make the tribe libs meta map filter unique to this plugin

### DIFF
--- a/core.php
+++ b/core.php
@@ -4,7 +4,7 @@
  * Plugin Name:       Tribe Alerts
  * Plugin URI:        https://github.com/moderntribe/tribe-alerts
  * Description:       Tribe Alerts WordPress Plugin
- * Version:           1.2.2
+ * Version:           1.2.3
  * Requires PHP:      7.4
  * Author:            Modern Tribe
  * Author URI:        https://tri.be

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -110,8 +110,10 @@ return [
 				return $content;
 			}
 
-			// Ensure our meta repo filter is unique from other tribe-libs instances
-			return str_replace( 'tribe_get_meta_repo', 'tribe_alerts_get_meta_repo_scoped', $content );
+			$filter = uniqid( 'tribe_alerts_get_meta_repo_' );
+
+			// Ensure our meta repo WP filter is unique from other tribe-libs instances
+			return str_replace( 'tribe_get_meta_repo', $filter, $content );
 		},
 	],
 

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -111,7 +111,7 @@ return [
 			}
 
 			// Ensure our meta repo filter is unique from other tribe-libs instances
-			return str_replace( 'tribe_get_meta_repo', 'tribe_get_meta_repo_scoped', $content );
+			return str_replace( 'tribe_get_meta_repo', 'tribe_alerts_get_meta_repo_scoped', $content );
 		},
 	],
 

--- a/src/Core.php
+++ b/src/Core.php
@@ -26,7 +26,7 @@ final class Core {
 
 	public const    PLUGIN_FILE        = 'plugin.file';
 	public const    VERSION_DEFINITION = 'plugin.version';
-	public const    VERSION            = '1.2.2';
+	public const    VERSION            = '1.2.3';
 	public const    RESOURCES_PATH     = 'plugin.resources_path';
 	public const    RESOURCES_URI      = 'plugin.resources_uri';
 	public const    DIST_DIR_PATH      = 'plugin.dist_dir_path';


### PR DESCRIPTION
- This will prevent conflicts with other plugins built with this starter so meta objects are loaded uniquely to this plugin itself.