### PR TITLE
Bugfix: Detect frontpage using $_SERVER REQUEST_URI

### DIFF
--- a/core.php
+++ b/core.php
@@ -4,7 +4,7 @@
  * Plugin Name:       Tribe Alerts
  * Plugin URI:        https://github.com/moderntribe/tribe-alerts
  * Description:       Tribe Alerts WordPress Plugin
- * Version:           1.5.0
+ * Version:           1.5.1
  * Requires PHP:      7.4
  * Author:            Modern Tribe
  * Author URI:        https://tri.be

--- a/dev/tests/tests/functional/Alert_Cest.php
+++ b/dev/tests/tests/functional/Alert_Cest.php
@@ -33,6 +33,11 @@ final class Alert_Cest {
 
 		update_field( Alert_Settings_Meta::FIELD_ACTIVE_ALERT, [ $alert_id ], 'option' );
 
+		$I->amOnPage( '/?var1=true&var2=true' );
+		$I->seeResponseCodeIs( 200 );
+		$I->seeElement( '.tribe-alerts' );
+		$I->see( 'Test included alert message' );
+
 		$I->amOnPage( '/' );
 		$I->seeResponseCodeIs( 200 );
 		$I->seeInSource( '<!-- tribe alerts -->' );
@@ -77,6 +82,11 @@ final class Alert_Cest {
 		update_field( Alert_Settings_Meta::FIELD_ACTIVE_ALERT, [ $alert_id ], 'option' );
 
 		$I->amOnPage( '/' );
+		$I->seeResponseCodeIs( 200 );
+		$I->seeInSource( '<!-- tribe alerts -->' );
+		$I->dontSeeElement( '.tribe-alerts' );
+
+		$I->amOnPage( '/?var1=true&var2=false' );
 		$I->seeResponseCodeIs( 200 );
 		$I->seeInSource( '<!-- tribe alerts -->' );
 		$I->dontSeeElement( '.tribe-alerts' );

--- a/src/Components/Alert/Rules/Excluded_Posts_Rule.php
+++ b/src/Components/Alert/Rules/Excluded_Posts_Rule.php
@@ -28,7 +28,7 @@ class Excluded_Posts_Rule implements Rule {
 
 		if ( $type === Alert_Meta::OPTION_EXCLUDE ) {
 			// If "always apply to front page" is checked.
-			if ( is_front_page() && $this->apply_to_front_page( $rules ) ) {
+			if ( $this->is_frontpage() && $this->apply_to_front_page( $rules ) ) {
 				return false;
 			}
 

--- a/src/Components/Alert/Rules/Included_Posts_Rule.php
+++ b/src/Components/Alert/Rules/Included_Posts_Rule.php
@@ -28,7 +28,7 @@ class Included_Posts_Rule implements Rule {
 
 		if ( $type === Alert_Meta::OPTION_INCLUDE ) {
 			// If "always apply to front page" is checked.
-			if ( is_front_page() && $this->apply_to_front_page( $rules ) ) {
+			if ( $this->is_frontpage() && $this->apply_to_front_page( $rules ) ) {
 				return true;
 			}
 

--- a/src/Components/Alert/Rules/Traits/With_Front_Page_Rule.php
+++ b/src/Components/Alert/Rules/Traits/With_Front_Page_Rule.php
@@ -25,4 +25,13 @@ trait With_Front_Page_Rule {
 		return (bool) ( $rules[ Alert_Meta::FIELD_RULES_APPLY_TO_FRONT_PAGE ] ?? false );
 	}
 
+	/**
+	 * Detect the frontpage regardless of what's set in Settings > Reading.
+	 */
+	protected function is_frontpage(): bool {
+		$uri = $_SERVER['REQUEST_URI'] ?? '';
+
+		return strtok( $uri, '?' ) === '/';
+	}
+
 }

--- a/src/Core.php
+++ b/src/Core.php
@@ -26,7 +26,7 @@ final class Core {
 
 	public const    PLUGIN_FILE        = 'plugin.file';
 	public const    VERSION_DEFINITION = 'plugin.version';
-	public const    VERSION            = '1.5.0';
+	public const    VERSION            = '1.5.1';
 	public const    RESOURCES_PATH     = 'plugin.resources_path';
 	public const    RESOURCES_URI      = 'plugin.resources_uri';
 	public const    DIST_DIR_PATH      = 'plugin.dist_dir_path';


### PR DESCRIPTION
- Frontpage detection in WordPress is so flaky, just detect the root URI instead