### PR TITLE
BUGFIX: Format output of alerts and don't double encode existing HTML entities.

### DIFF
--- a/dev/tests/tests/functional/Alert_Cest.php
+++ b/dev/tests/tests/functional/Alert_Cest.php
@@ -279,11 +279,11 @@ final class Alert_Cest {
 		delete_option( 'page_for_posts' );
 	}
 
-	public function test_it_displays_a_global_alert_on_multiple_urls( FunctionalTester $I ): void {
+	public function test_it_displays_a_global_alert_on_multiple_urls_with_encoding( FunctionalTester $I ): void {
 		$alert_id = $I->havePostInDatabase( [
 			'post_type'   => Alert::NAME,
 			'post_status' => 'publish',
-			'post_title'  => 'Test global alert',
+			'post_title'  => 'Test global alert with "Double Quotes" & \'Single Quotes\'',
 		] );
 
 		$I->havePostInDatabase( [
@@ -293,7 +293,7 @@ final class Alert_Cest {
 			'post_name'   => 'regular-post',
 		] );
 
-		update_field( Alert_Meta::FIELD_MESSAGE, 'Test alert message', $alert_id );
+		update_field( Alert_Meta::FIELD_MESSAGE, 'Test alert message "Double Quotes" & \'Single Quotes\'', $alert_id );
 		update_field( Alert_Meta::GROUP_RULES, [
 			Alert_Meta::FIELD_RULES_DISPLAY_TYPE  => Alert_Meta::OPTION_EVERY_PAGE,
 			Alert_Meta::FIELD_RULES_INCLUDE_PAGES => [],
@@ -304,25 +304,29 @@ final class Alert_Cest {
 
 		$I->amOnPage( '/' );
 		$I->seeElement( '.tribe-alerts' );
-		$I->see( 'Test alert message' );
+		$I->seeInSource( 'Test global alert with &#8220;Double Quotes&#8221; &#038; &#8216;Single Quotes&#8217;' );
+		$I->seeInSource( 'Test alert message &#8220;Double Quotes&#8221; &#038; &#8216;Single Quotes&#8217;' );
 
 		$I->amOnPage( '/regular-post' );
 		$I->seeResponseCodeIs( 200 );
 		$I->seeInSource( '<!-- tribe alerts -->' );
 		$I->seeElement( '.tribe-alerts' );
-		$I->see( 'Test alert message' );
+		$I->seeInSource( 'Test global alert with &#8220;Double Quotes&#8221; &#038; &#8216;Single Quotes&#8217;' );
+		$I->seeInSource( 'Test alert message &#8220;Double Quotes&#8221; &#038; &#8216;Single Quotes&#8217;' );
 
 		$I->amOnPage( '/?s=meep' );
 		$I->seeResponseCodeIs( 200 );
 		$I->seeInSource( '<!-- tribe alerts -->' );
 		$I->seeElement( '.tribe-alerts' );
-		$I->see( 'Test alert message' );
+		$I->seeInSource( 'Test global alert with &#8220;Double Quotes&#8221; &#038; &#8216;Single Quotes&#8217;' );
+		$I->seeInSource( 'Test alert message &#8220;Double Quotes&#8221; &#038; &#8216;Single Quotes&#8217;' );
 
 		$I->amOnPage( '/category/uncategorized/' );
 		$I->seeResponseCodeIs( 200 );
 		$I->seeInSource( '<!-- tribe alerts -->' );
 		$I->seeElement( '.tribe-alerts' );
-		$I->see( 'Test alert message' );
+		$I->seeInSource( 'Test global alert with &#8220;Double Quotes&#8221; &#038; &#8216;Single Quotes&#8217;' );
+		$I->seeInSource( 'Test alert message &#8220;Double Quotes&#8221; &#038; &#8216;Single Quotes&#8217;' );
 	}
 
 	public function test_it_does_not_display_on_a_404_page( FunctionalTester $I ): void {

--- a/resources/views/alert.php
+++ b/resources/views/alert.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use function Tribe\Alert\format_content;
+
 /**
  * @var \League\Plates\Template\Template        $this
  * @var \Tribe\Alert\Components\Alert\Alert_Dto $dto
@@ -26,18 +28,18 @@
 		</button>
 
 		<?php if ( $dto->title ) : ?>
-			<h2 class="tribe-alerts__title"><?php echo $this->e( $dto->title ); ?></h2>
+			<h2 class="tribe-alerts__title"><?php echo esc_html( $dto->title ) ?></h2>
 		<?php endif; ?>
 
 		<?php if ( $dto->content ) : ?>
-			<div class="tribe-alerts__content"><?php echo $this->e( $dto->content ); ?></div>
+			<div class="tribe-alerts__content"><?php echo esc_html( format_content( $dto->content ) ) ?></div>
 		<?php endif; ?>
 
 		<?php if ( $dto->cta->url ) : ?>
 			<a class="a-link tribe-alerts__link"
 				<?php echo $link_attributes; ?>
-			   href="<?php echo $this->e( $dto->cta->url, 'esc_url' ); ?>">
-				<?php echo $this->e( $dto->cta->title ); ?>
+			   href="<?php echo esc_url( $dto->cta->url ) ?>">
+				<?php echo esc_html( format_content( $dto->cta->title ) ) ?>
 			</a>
 		<?php endif; ?>
 	</div>

--- a/src/functions.php
+++ b/src/functions.php
@@ -19,3 +19,14 @@ function render_alert(): void {
 
 	tribe_alert()->get_container()->get( Alert_Controller::class )->render();
 }
+
+/**
+ * Format content that is not already formatted out of the box by WordPress.
+ *
+ * @param string $content The content to format.
+ *
+ * @return string The formatted content.
+ */
+function format_content( string $content ): string {
+	return convert_chars( wptexturize( $content ) );
+}


### PR DESCRIPTION
WordPress automatically encodes post titles and other specific parts of a post, but not other fields. Currently if a user entered special entities like `Terms & Conditions` it would display a double encoded version of that. 

This update encodes the alert content and the hyperlink text and then performs escaping after to both standardize output and fix this bug.